### PR TITLE
Update resource names to reflect the http methods

### DIFF
--- a/ehr-connectivity/epic-fhirr4-medications-api-service/service.bal
+++ b/ehr-connectivity/epic-fhirr4-medications-api-service/service.bal
@@ -45,7 +45,7 @@ service / on new fhirr4:Listener(9090, medicationApiConfig) {
     }
 
     // Search for resources based on some filter criteria.
-    isolated resource function search fhir/r4/Medication(r4:FHIRContext fhirContext) returns @http:Payload {mediaType: ["application/fhir+json"]} r4:Bundle|r4:FHIRError {
+    isolated resource function get fhir/r4/Medication(r4:FHIRContext fhirContext) returns @http:Payload {mediaType: ["application/fhir+json"]} r4:Bundle|r4:FHIRError {
         r4:Bundle|error fhirInteractionResult = executeFhirInteraction("Medication", fhirContext, (), (), Medication).ensureType(r4:Bundle);
         if fhirInteractionResult is error {
             return r4:createFHIRError("Error occurred while executing the Observation search interaction.", r4:CODE_SEVERITY_ERROR,
@@ -55,7 +55,7 @@ service / on new fhirr4:Listener(9090, medicationApiConfig) {
     }
 
     // Create a new resource with a server assigned id.
-    isolated resource function create fhir/r4/Medication(r4:FHIRContext fhirContext, uscore:USCoreMedicationProfile medication) returns @http:Payload {mediaType: ["application/fhir+json"]} Medication|r4:FHIRError {
+    isolated resource function post fhir/r4/Medication(r4:FHIRContext fhirContext, uscore:USCoreMedicationProfile medication) returns @http:Payload {mediaType: ["application/fhir+json"]} Medication|r4:FHIRError {
         Medication|error fhirInteractionResult = executeFhirInteraction("Medication", fhirContext, (), medication, Medication).ensureType(Medication);
         if fhirInteractionResult is error {
             return r4:createFHIRError("Error occurred while executing the Observation create interaction.", r4:CODE_SEVERITY_ERROR,
@@ -78,7 +78,7 @@ service / on new fhirr4:Listener(9091, immunizationApiConfig) {
     }
 
     // Search for resources based on some filter criteria.
-    isolated resource function search fhir/r4/Immunization(r4:FHIRContext fhirContext) returns @http:Payload {mediaType: ["application/fhir+json"]} r4:Bundle|r4:FHIRError {
+    isolated resource function get fhir/r4/Immunization(r4:FHIRContext fhirContext) returns @http:Payload {mediaType: ["application/fhir+json"]} r4:Bundle|r4:FHIRError {
         r4:Bundle|error fhirInteractionResult = executeFhirInteraction("Immunization", fhirContext, (), (), Immunization).ensureType(r4:Bundle);
         if fhirInteractionResult is error {
             return r4:createFHIRError("Error occurred while executing the Observation search interaction.", r4:CODE_SEVERITY_ERROR,
@@ -88,7 +88,7 @@ service / on new fhirr4:Listener(9091, immunizationApiConfig) {
     }
 
     // Create a new resource with a server assigned id.
-    isolated resource function create fhir/r4/Immunization(r4:FHIRContext fhirContext, uscore:USCoreImmunizationProfile immunization) returns @http:Payload {mediaType: ["application/fhir+json"]} Immunization|r4:FHIRError {
+    isolated resource function post fhir/r4/Immunization(r4:FHIRContext fhirContext, uscore:USCoreImmunizationProfile immunization) returns @http:Payload {mediaType: ["application/fhir+json"]} Immunization|r4:FHIRError {
         Immunization|error fhirInteractionResult = executeFhirInteraction("Immunization", fhirContext, (), immunization, Immunization).ensureType(Immunization);
         if fhirInteractionResult is error {
             return r4:createFHIRError("Error occurred while executing the Observation create interaction.", r4:CODE_SEVERITY_ERROR,
@@ -111,7 +111,7 @@ service / on new fhirr4:Listener(9092, medicationrequestApiConfig) {
     }
 
     // Search for resources based on some filter criteria.
-    isolated resource function search fhir/r4/MedicationRequest(r4:FHIRContext fhirContext) returns @http:Payload {mediaType: ["application/fhir+json"]} r4:Bundle|r4:FHIRError {
+    isolated resource function get fhir/r4/MedicationRequest(r4:FHIRContext fhirContext) returns @http:Payload {mediaType: ["application/fhir+json"]} r4:Bundle|r4:FHIRError {
         r4:Bundle|error fhirInteractionResult = executeFhirInteraction("MedicationRequest", fhirContext, (), (), MedicationRequest).ensureType(r4:Bundle);
         if fhirInteractionResult is error {
             return r4:createFHIRError("Error occurred while executing the Observation search interaction.", r4:CODE_SEVERITY_ERROR,
@@ -121,7 +121,7 @@ service / on new fhirr4:Listener(9092, medicationrequestApiConfig) {
     }
 
     // Create a new resource with a server assigned id.
-    isolated resource function create fhir/r4/MedicationRequest(r4:FHIRContext fhirContext, uscore:USCoreMedicationRequestProfile medicationRequest) returns @http:Payload {mediaType: ["application/fhir+json"]} MedicationRequest|r4:FHIRError {
+    isolated resource function post fhir/r4/MedicationRequest(r4:FHIRContext fhirContext, uscore:USCoreMedicationRequestProfile medicationRequest) returns @http:Payload {mediaType: ["application/fhir+json"]} MedicationRequest|r4:FHIRError {
         MedicationRequest|error fhirInteractionResult = executeFhirInteraction("MedicationRequest", fhirContext, (), medicationRequest, MedicationRequest).ensureType(MedicationRequest);
         if fhirInteractionResult is error {
             return r4:createFHIRError("Error occurred while executing the Observation create interaction.", r4:CODE_SEVERITY_ERROR,
@@ -144,7 +144,7 @@ service / on new fhirr4:Listener(9093, medicationstatementApiConfig) {
     }
 
     // Search for resources based on some filter criteria.
-    isolated resource function search fhir/r4/MedicationStatement(r4:FHIRContext fhirContext) returns @http:Payload {mediaType: ["application/fhir+json"]} r4:Bundle|r4:FHIRError {
+    isolated resource function get fhir/r4/MedicationStatement(r4:FHIRContext fhirContext) returns @http:Payload {mediaType: ["application/fhir+json"]} r4:Bundle|r4:FHIRError {
         r4:Bundle|error fhirInteractionResult = executeFhirInteraction("MedicationStatement", fhirContext, (), (), MedicationStatement).ensureType(r4:Bundle);
         if fhirInteractionResult is error {
             return r4:createFHIRError("Error occurred while executing the Observation search interaction.", r4:CODE_SEVERITY_ERROR,
@@ -154,7 +154,7 @@ service / on new fhirr4:Listener(9093, medicationstatementApiConfig) {
     }
 
     // Create a new resource with a server assigned id.
-    isolated resource function create fhir/r4/MedicationStatement(r4:FHIRContext fhirContext, international401:MedicationStatement medicationStatement) returns @http:Payload {mediaType: ["application/fhir+json"]} MedicationStatement|r4:FHIRError {
+    isolated resource function post fhir/r4/MedicationStatement(r4:FHIRContext fhirContext, international401:MedicationStatement medicationStatement) returns @http:Payload {mediaType: ["application/fhir+json"]} MedicationStatement|r4:FHIRError {
         MedicationStatement|error fhirInteractionResult = executeFhirInteraction("MedicationStatement", fhirContext, (), medicationStatement, MedicationStatement).ensureType(MedicationStatement);
         if fhirInteractionResult is error {
             return r4:createFHIRError("Error occurred while executing the Observation create interaction.", r4:CODE_SEVERITY_ERROR,


### PR DESCRIPTION
Update resource names, 'create' and 'search' to 'get' and 'post', to reflect the respective http methods